### PR TITLE
Use Hardware::CPU.is_64_bit? instead of Hardware.is_64_bit?

### DIFF
--- a/grabeni.rb
+++ b/grabeni.rb
@@ -3,7 +3,7 @@ class Grabeni < Formula
   homepage 'https://github.com/yuuki/grabeni'
   version grabeni_version
 
-  if Hardware.is_64_bit?
+  if Hardware::CPU.is_64_bit?
     url "https://github.com/yuuki/grabeni/releases/download/v#{grabeni_version}/grabeni_darwin_amd64.zip"
     sha256 '628507fffbd8895acc2e00b2ab2a8c7f970a3dad3775a8517bb452616ff024af'
   else


### PR DESCRIPTION
Ref: https://github.com/mackerelio/homebrew-mackerel-agent/pull/16

With recent Homebrew change( https://github.com/Homebrew/brew/commit/b950966bdde86e6bc059d08c3b18852e369e09bb ), calling `Hardware.is_64_bit?` (which has became deprecated at https://github.com/Homebrew/legacy-homebrew/pull/18547 ) produces a warning message.

```
Warning: Calling Hardware.is_64_bit? is deprecated!
Use Hardware::CPU.is_64_bit? instead.
/usr/local/Library/Taps/yuuki/homebrew-grabeni/grabeni.rb:6:in `<class:Grabeni>'
Please report this to the yuuki/grabeni tap!
```
